### PR TITLE
Improve the logic for PDF Processing

### DIFF
--- a/collector/utils/constants.js
+++ b/collector/utils/constants.js
@@ -29,7 +29,7 @@ const SUPPORTED_FILETYPE_CONVERTERS = {
   ".jpg": "./convert/asImage.js",
   ".png": "./convert/asImage.js",
   ".jpeg": "./convert/asImage.js",
-  ".pdf": "./convert/asImage.js",
+  ".pdf": "./convert/asPDF.js",
   ".txt": "./convert/asTxt.js",
   ".md": "./convert/asTxt.js",
   ".org": "./convert/asTxt.js",

--- a/collector/utils/streamToBuffer/index.js
+++ b/collector/utils/streamToBuffer/index.js
@@ -1,0 +1,9 @@
+module.exports = async function streamToBuffer(stream) {
+    return new Promise((resolve, reject) => {
+      const chunks = [];
+      stream.on("data", (chunk) => chunks.push(chunk));
+      stream.on("end", () => resolve(Buffer.concat(chunks)));
+      stream.on("error", (err) => reject(err));
+    });
+  };
+  


### PR DESCRIPTION
This PR optimizes PDF processing by checking the content type before proceeding:

1. If the PDF is empty, it uses Textract for data extraction and rewriting.
2. If the PDF already contains content, it processes the existing text or images without invoking Textract.


**PDF with text content only:**
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/3ce2dad8-071b-4dc4-b6dd-ba6d4c039b7d">

**PDF with image content only:**
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/3ca7e17f-7798-4b40-b217-0b3ba64463e2">
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/885168da-9d53-4f85-9f65-f1bb8cc6041e">

For both, tried to test it by embedding to workspace and asking question related to it